### PR TITLE
keep up with linux kernel changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ EXTRA_CFLAGS += -Wno-implicit-fallthrough
 EXTRA_CFLAGS += -Wno-discarded-qualifiers
 EXTRA_CFLAGS += -Wno-cast-function-type
 EXTRA_CFLAGS += -Wno-address
+EXTRA_CFLAGS += -Wno-date-time
 #EXTRA_CFLAGS += -Wno-uninitialized
 
 GCC_VER_49 := $(shell echo `$(CC) -dumpversion | cut -f1-2 -d.` \>= 4.9 | bc )

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -438,7 +438,9 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
 	if (started) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false, 0);
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false);
@@ -453,7 +455,9 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 
 	if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
 		goto exit;
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
+#if(LINUX_VERSION_CODE >= KERNEL_VERSION(6, 9, 0))
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false);
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
@@ -5097,6 +5101,7 @@ exit:
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0))
 static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
 		struct cfg80211_beacon_data *info)
 {
@@ -5109,6 +5114,20 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 
 	return ret;
 }
+#else
+static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
+		struct cfg80211_ap_update *params)
+{
+	int ret = 0;
+	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
+
+	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
+
+	ret = rtw_add_beacon(adapter, params->beacon.head, params->beacon.head_len, params->beacon.tail, params->beacon.tail_len);
+
+	return ret;
+}
+#endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
 static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev, unsigned int link_id)

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -322,8 +322,10 @@ struct rtw_usb_drv usb_drv = {
 	.usbdrv.supports_autosuspend = 1,
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 19) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0))
 	.usbdrv.drvwrap.driver.shutdown = rtw_dev_shutdown,
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
+	.usbdrv.driver.shutdown = rtw_dev_shutdown,
 #else
 	.usbdrv.driver.shutdown = rtw_dev_shutdown,
 #endif


### PR DESCRIPTION
1. add -Wno-date-time to ignore reproduceable build warnning. 

2. linux kernel change usbdrv_wrap to device_driver in struct usb_driver. detail: [usbdrv_wrap to device_driver](https://github.com/torvalds/linux/commit/49a78b05d5ca1e23fd737747a8757b8bdc319b30#diff-518c3f16ec483153d37a92484e4b63bd8410442f44f1e501751008cbc467e4d2)
3. linux kernel change cfg80211_ap_settings to cfg80211_ap_update in struct cfg80211_ops. detail: [cfg80211_ap_settings to cfg80211_ap_update](https://github.com/torvalds/linux/commit/bb55441c57ccc5cc2eab44e1a97698b9d708871d#diff-f08713dc20903b704b702c24a367b96bb9a7308e9421fdce11d0028bf159f878)
4. linux kernel move parameter "punct_bitmap" into "chandef" of function "cfg80211_ch_switch_notify". [move "punct_bitmap" into "chandef](https://github.com/torvalds/linux/commit/b82730bf57b54803ab94abbfd8c4422a7081886d#diff-f08713dc20903b704b702c24a367b96bb9a7308e9421fdce11d0028bf159f878)